### PR TITLE
Make CKEditorRenderer constructor backward compatible

### DIFF
--- a/Tests/Renderer/CKEditorRendererTest.php
+++ b/Tests/Renderer/CKEditorRendererTest.php
@@ -95,6 +95,33 @@ class CKEditorRendererTest extends AbstractTestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation Passing a %s as %s first argument is deprecated since %s, and will be removed in %s. Use %s instead.
+     */
+    public function testLegacyContstructor()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->exactly(5))
+            ->method('get')
+            ->withConsecutive(
+                ['ivory_ck_editor.renderer.json_builder'],
+                ['router'],
+                ['assets.packages'],
+                ['request_stack'],
+                ['templating']
+            )
+            ->willReturnMap([
+                ['ivory_ck_editor.renderer.json_builder', new JsonBuilder()],
+                ['router', $this->router],
+                ['assets.packages', $this->packages],
+                ['request_stack', $this->requestStack],
+                ['templating', $this->templating],
+            ]);
+
+        new CKEditorRenderer($container);
+    }
+
+    /**
      * @param string $path
      * @param string $asset
      * @param string $url

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,4 +16,7 @@
             </exclude>
         </whitelist>
     </filter>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Here is my BC constructor for CKEditorRenderer with a deprecation notice for using `ContainerInterface` as first argument.

I didn't used a `ServiceLocator` as in Symfony 3.4, the user will get deprecation notices from Symfony about getting services from the container.

The only configuration not working is injecting the `service_container` with Symfony 4.